### PR TITLE
docs: add getting started guide for new contributors (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ It enables instant stablecoin payments, automated escrow, and tokenized invoice 
 🔐 On-chain settlement and dispute resolution for security and auditability
 
 
+## Getting Started
+
+This guide helps new contributors set up FinovatePay locally.
+
+### Prerequisites
+- Node.js (v18+ recommended)
+- npm or yarn
+- MetaMask wallet
+- Polygon RPC endpoint
+
+### Clone the Repository
+```bash
+git clone https://github.com/<your-username>/FinovatePay.git
+cd FinovatePay
+
+
 
 ## 🔧 Tech Stack
 


### PR DESCRIPTION
Closes #2

### What this PR does
- Adds a clear Getting Started section to the README
- Documents frontend, backend, and smart contract setup
- Improves onboarding experience for new contributors

### Why
New contributors may face difficulty setting up the project locally without clear setup instructions.

### Type
Documentation improvement
