### PR TITLE
fix: hide investor sidebar tabs which were not required

### DIFF
--- a/frontend/src/components/Dashboard/Sidebar.jsx
+++ b/frontend/src/components/Dashboard/Sidebar.jsx
@@ -20,11 +20,12 @@ const Sidebar = ({ activeTab, onTabChange, user, stats }) => {
     tabs.push({ id: 'admin', label: 'Admin', icon: '⚙️' });
   }
 
+  const visibleTabs = user?.role === 'investor' ? tabs.filter(tab => !['quotations', 'invoices', 'payments', 'produce', 'escrow'].includes(tab.id)) : tabs;
   return (
     <div className="bg-white shadow-md rounded-lg p-4 h-fit">
       <h2 className="text-lg font-semibold mb-4">Navigation</h2>
       <ul className="space-y-2">
-        {tabs.map(tab => (
+        {visibleTabs.map(tab => (
           <li key={tab.id}>
             <button
               onClick={() => onTabChange(tab.id)}


### PR DESCRIPTION
### Summary: (Issue https://github.com/GauravKarakoti/FinovatePay/issues/22)

- Update the sidebar for the **Investor** role so unrelated tabs are hidden (Quotation, Invoice, Payment, Produce, Escrow).
- Kept code clean and other tabs' option visible.
