### PR TITLE
Add reason to account freeze events for KYC/AML transparency

### DIFF
--- a/contracts/ComplianceManager.sol
+++ b/contracts/ComplianceManager.sol
@@ -10,7 +10,7 @@ contract ComplianceManager is ERC721, Ownable {
     mapping(address => bool) private kycVerified;
     mapping(address => uint256) public userTokenId;
     
-    event AccountFrozen(address indexed account);
+    event AccountFrozen(address indexed account,string reason);
     event AccountUnfrozen(address indexed account);
     event KYCVerified(address indexed account);
     event KYCRevoked(address indexed account);
@@ -22,9 +22,9 @@ contract ComplianceManager is ERC721, Ownable {
      */
     constructor() ERC721("FinovateVerified", "FVT-ID") Ownable(msg.sender) {}
     
-    function freezeAccount(address _account) external onlyOwner {
+    function freezeAccount(address _account,string calldata reason) external onlyOwner {
         frozenAccounts[_account] = true;
-        emit AccountFrozen(_account);
+        emit AccountFrozen(_account,reason);
     }
     
     function unfreezeAccount(address _account) external onlyOwner {


### PR DESCRIPTION
This PR adds a reason parameter to the AccountFrozen event so that the cause of an account freeze is visible on-chain. When an account is frozen, the reason is emitted in the event log, allowing teams and integrators to see why the action was taken without changing any existing freeze or KYC logic.

Closes #42
