### PR TITLE
Prepare ComplianceManager for Polygon CDK runtime compliance integration

### DIFF
--- a/contracts/ComplianceManager.sol
+++ b/contracts/ComplianceManager.sol
@@ -3,13 +3,15 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "./interfaces/IComplianceRegistry.sol";
 
 contract ComplianceManager is ERC721, Ownable {
     uint256 private _nextTokenId;
     mapping(address => bool) private frozenAccounts;
     mapping(address => bool) private kycVerified;
     mapping(address => uint256) public userTokenId;
-    
+    IComplianceRegistry public complianceRegistry;
+
     event AccountFrozen(address indexed account,string reason);
     event AccountUnfrozen(address indexed account);
     event KYCVerified(address indexed account);
@@ -21,7 +23,12 @@ contract ComplianceManager is ERC721, Ownable {
      * @dev Sets the contract deployer as the initial owner.
      */
     constructor() ERC721("FinovateVerified", "FVT-ID") Ownable(msg.sender) {}
-    
+
+    function setComplianceRegistry(address registry) external onlyOwner {
+        require(registry != address(0), "Invalid registry");
+        complianceRegistry = IComplianceRegistry(registry);
+    }
+
     function freezeAccount(address _account,string calldata reason) external onlyOwner {
         frozenAccounts[_account] = true;
         emit AccountFrozen(_account,reason);
@@ -42,17 +49,23 @@ contract ComplianceManager is ERC721, Ownable {
         emit KYCRevoked(_account);
     }
     
-    function isFrozen(address _account) external view returns (bool) {
+    function isFrozen(address _account) public view returns (bool) {
+        if (address(complianceRegistry) != address(0)) {
+            return complianceRegistry.isFrozen(_account);
+        }
         return frozenAccounts[_account];
     }
     
-    function isKYCVerified(address _account) external view returns (bool) {
+    function isKYCVerified(address _account) public view returns (bool) {
+        if (address(complianceRegistry) != address(0)) {
+            return complianceRegistry.isKYCVerified(_account);
+        }
         return kycVerified[_account];
     }
     
     modifier onlyCompliant(address _account) {
-        require(!frozenAccounts[_account], "Account is frozen");
-        require(kycVerified[_account], "KYC not verified");
+        require(!isFrozen(_account), "Account is frozen");
+        require(isKYCVerified(_account), "KYC not verified");
         _;
     }
 
@@ -76,7 +89,10 @@ contract ComplianceManager is ERC721, Ownable {
         emit IdentityRevoked(from, tokenId);
     }
 
-    function hasIdentity(address account) external view returns (bool) {
+    function hasIdentity(address account) public view returns (bool) {
+        if (address(complianceRegistry) != address(0)) {
+            return complianceRegistry.hasIdentity(account);
+        }
         return balanceOf(account) > 0;
     }
 

--- a/contracts/interfaces/IComplianceRegistry.sol
+++ b/contracts/interfaces/IComplianceRegistry.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IComplianceRegistry
+ * @dev Interface for future Polygon CDK compliance precompile / runtime module.
+ * This allows ComplianceManager to delegate compliance checks to chain-level logic.
+ */
+interface IComplianceRegistry {
+    function isFrozen(address user) external view returns (bool);
+    function isKYCVerified(address user) external view returns (bool);
+    function hasIdentity(address user) external view returns (bool);
+}


### PR DESCRIPTION
This refactor prepares ComplianceManager for migration of compliance logic to Polygon CDK chain-level modules.

Compliance modules identified for runtime migration:
1. account freeze enforcement
2. KYC verification checks
3. identity presence checks
4. onlyCompliant modifier logic

Changes:
1. added IComplianceRegistry interface
2. added pluggable complianceRegistry
3. isFrozen, isKYCVerified, hasIdentity now read from registry if set, else fallback to local mappings
4. no change to current behavior or admin workflows

Enables future use of CDK precompiles/hooks without breaking existing deployments.

This PR implements the contract-side migration layer; runtime precompile and hook implementation will follow in the CDK chain environment.

Closes #17
