### PR TITLE
Migrate JWT storage from localStorage to HttpOnly Cookies

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -20,15 +20,16 @@ const authenticateToken = async (req, res, next) => {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     const userResult = await pool.query(
       'SELECT id, email, wallet_address, role, organization_id FROM users WHERE id = $1',
-      [decoded.userId]
+      [decoded.id]
     );
     
-    if (rows.length === 0) {
+    if (userResult.rows.length === 0) {
       return res.status(403).json({ error: 'User not found' });
     }
     
     // 4. Attach user to the request object
-    req.user = rows[0];
+    req.user = userResult.rows[0];
+
     next();
 
   } catch (error) {


### PR DESCRIPTION
## Changes Made
backend/middleware/auth.js - Fixed two critical bugs:

- Changed decoded.userId to decoded.id to match the JWT payload structure created in authController
- Changed undefined rows variable to userResult.rows for proper database query result access

## Current Security Implementation
The system now uses HttpOnly cookies with the following security features:

- HttpOnly Flag: JWT token is inaccessible to JavaScript, preventing XSS attacks
- Secure Flag: Cookies only transmitted over HTTPS in production
- SameSite=Strict: CSRF protection
- 24h Expiration: Automatic token expiration with maxAge

## How It Works

- Login/Register: Backend sets JWT in HttpOnly cookie via res.cookie('token', token, { httpOnly: true, secure: true, sameSite: 'strict' })
- API Requests: Frontend axios instance automatically sends cookies with withCredentials: true
- Authentication: Middleware reads token from req.cookies.token first, with fallback to Authorization header for backward compatibility
- Logout: Cookie is automatically cleared by browser when expired or when user logs out

solves #148