### PR TITLE
feat: make frontend components mobile responsive

### DIFF
--- a/frontend/src/components/Dashboard/PaymentHistoryList.jsx
+++ b/frontend/src/components/Dashboard/PaymentHistoryList.jsx
@@ -14,37 +14,71 @@ const PaymentHistoryList = ({ invoices, userRole }) => {
                 <h3 className="text-lg font-semibold">Completed Payments</h3>
             </div>
             {invoices.length > 0 ? (
-                <div className="overflow-x-auto">
-                    <table className="min-w-full divide-y divide-gray-200">
-                        <thead className="bg-gray-50">
-                            <tr>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Completion Date</th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Invoice ID</th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Amount</th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Counterparty</th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Transaction</th>
-                            </tr>
-                        </thead>
-                        <tbody className="bg-white divide-y divide-gray-200">
-                            {invoices.map((invoice) => (
-                                <tr key={invoice.invoice_id}>
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{formatDate(invoice.updated_at)}</td>
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{formatAddress(invoice.invoice_id)}</td>
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm">
-                                       {/* ✅ UPDATED HERE */}
-                                       <AmountDisplay maticAmount={invoice.amount} />
-                                    </td>
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{formatAddress(userRole === 'buyer' ? invoice.seller_address : invoice.buyer_address)}</td>
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-blue-600">
-                                        <a href={`${blockExplorerUrl}${invoice.release_tx_hash}`} target="_blank" rel="noopener noreferrer" className="hover:underline">
-                                            View on Explorer
-                                        </a>
-                                    </td>
+                <>
+                    {/* Desktop Table View */}
+                    <div className="hidden md:block overflow-x-auto">
+                        <table className="min-w-full divide-y divide-gray-200">
+                            <thead className="bg-gray-50">
+                                <tr>
+                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Completion Date</th>
+                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Invoice ID</th>
+                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Amount</th>
+                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Counterparty</th>
+                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Transaction</th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
+                            </thead>
+                            <tbody className="bg-white divide-y divide-gray-200">
+                                {invoices.map((invoice) => (
+                                    <tr key={invoice.invoice_id}>
+                                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{formatDate(invoice.updated_at)}</td>
+                                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{formatAddress(invoice.invoice_id)}</td>
+                                        <td className="px-6 py-4 whitespace-nowrap text-sm">
+                                           {/* ✅ UPDATED HERE */}
+                                           <AmountDisplay maticAmount={invoice.amount} />
+                                        </td>
+                                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">{formatAddress(userRole === 'buyer' ? invoice.seller_address : invoice.buyer_address)}</td>
+                                        <td className="px-6 py-4 whitespace-nowrap text-sm text-blue-600">
+                                            <a href={`${blockExplorerUrl}${invoice.release_tx_hash}`} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                                                View on Explorer
+                                            </a>
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {/* Mobile Card View */}
+                    <div className="md:hidden space-y-4 p-4">
+                        {invoices.map((invoice) => (
+                            <div key={invoice.invoice_id} className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
+                                <div className="flex justify-between items-start mb-2">
+                                    <div className="text-sm font-medium text-gray-900">
+                                        ID: {formatAddress(invoice.invoice_id)}
+                                    </div>
+                                    <div className="text-sm text-gray-500">{formatDate(invoice.updated_at)}</div>
+                                </div>
+                                <div className="mb-2">
+                                    <div className="text-sm font-semibold">
+                                        <AmountDisplay maticAmount={invoice.amount} />
+                                    </div>
+                                </div>
+                                <div className="text-xs text-gray-500 mb-3">
+                                    <span className="font-semibold">{userRole === 'buyer' ? 'Seller' : 'Buyer'}:</span> {formatAddress(userRole === 'buyer' ? invoice.seller_address : invoice.buyer_address)}
+                                </div>
+                                <a 
+                                    href={`${blockExplorerUrl}${invoice.release_tx_hash}`} 
+                                    target="_blank" 
+                                    rel="noopener noreferrer" 
+                                    className="text-sm text-blue-600 hover:text-blue-800 font-medium flex items-center gap-1"
+                                >
+                                    View Transaction
+                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                                </a>
+                            </div>
+                        ))}
+                    </div>
+                </>
             ) : (
                 <div className="text-center py-12 text-gray-500">
                     <p>No completed payments found.</p>

--- a/frontend/src/components/Dashboard/QuotationList.jsx
+++ b/frontend/src/components/Dashboard/QuotationList.jsx
@@ -19,9 +19,38 @@ const QuotationList = ({ quotations, userRole, onApprove, onReject, onCreateInvo
         return <span className={`px-2 py-1 rounded-full text-xs font-medium capitalize ${color}`}>{label}</span>;
     };
 
+    const renderActions = (q) => (
+        <div className="flex flex-wrap gap-2 items-center text-sm font-medium">
+            {/* SELLER ACTIONS */}
+            {userRole === 'seller' && q.status === 'pending_seller_approval' && (
+                <>
+                    <button onClick={() => onApprove(q.id)} className="text-green-600 hover:text-green-900 font-semibold text-xs border border-green-600 px-2 py-1 rounded hover:bg-green-50">Approve</button>
+                    <button onClick={() => onReject(q.id)} className="text-red-600 hover:text-red-900 font-semibold text-xs border border-red-600 px-2 py-1 rounded hover:bg-red-50">Reject</button>
+                </>
+            )}
+            {userRole === 'seller' && q.status === 'approved' && (
+                <button onClick={() => onCreateInvoice(q)} className="text-white bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded-md text-xs shadow-sm">
+                    Create Invoice
+                </button>
+            )}
+
+            {/* BUYER ACTIONS */}
+            {userRole === 'buyer' && q.status === 'pending_buyer_approval' && (
+                <>
+                    <button onClick={() => onApprove(q.id)} className="text-green-600 hover:text-green-900 font-semibold text-xs border border-green-600 px-2 py-1 rounded hover:bg-green-50">Approve</button>
+                    <button onClick={() => onReject(q.id)} className="text-red-600 hover:text-red-900 font-semibold text-xs border border-red-600 px-2 py-1 rounded hover:bg-red-50">Reject</button>
+                </>
+            )}
+            {(userRole === 'buyer' && q.status === 'pending_seller_approval') && (
+               <button onClick={() => onReject(q.id)} className="text-red-600 hover:text-red-900 font-semibold text-xs">Cancel</button>
+            )}
+        </div>
+    );
+
     return (
         <div className="bg-white rounded-lg shadow-md overflow-hidden">
-            <div className="overflow-x-auto">
+            {/* Desktop Table View */}
+            <div className="hidden md:block overflow-x-auto">
                 <table className="min-w-full divide-y divide-gray-200">
                     <thead className="bg-gray-50">
                         <tr>
@@ -44,35 +73,41 @@ const QuotationList = ({ quotations, userRole, onApprove, onReject, onCreateInvo
                                 </td>
                                 <td className="px-6 py-4 whitespace-nowrap">{getStatusBadge(q.status)}</td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-2">
-                                    {/* SELLER ACTIONS */}
-                                    {userRole === 'seller' && q.status === 'pending_seller_approval' && (
-                                        <>
-                                            <button onClick={() => onApprove(q.id)} className="text-green-600 hover:text-green-900">Approve</button>
-                                            <button onClick={() => onReject(q.id)} className="text-red-600 hover:text-red-900">Reject</button>
-                                        </>
-                                    )}
-                                    {userRole === 'seller' && q.status === 'approved' && (
-                                        <button onClick={() => onCreateInvoice(q)} className="text-white bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded-md text-xs">
-                                            Create Invoice
-                                        </button>
-                                    )}
-
-                                    {/* BUYER ACTIONS */}
-                                    {userRole === 'buyer' && q.status === 'pending_buyer_approval' && (
-                                        <>
-                                            <button onClick={() => onApprove(q.id)} className="text-green-600 hover:text-green-900">Approve</button>
-                                            <button onClick={() => onReject(q.id)} className="text-red-600 hover:text-red-900">Reject</button>
-                                        </>
-                                    )}
-                                    {(userRole === 'buyer' && q.status === 'pending_seller_approval') && (
-                                       <button onClick={() => onReject(q.id)} className="text-red-600 hover:text-red-900">Cancel</button>
-                                    )}
+                                    {renderActions(q)}
                                 </td>
                             </tr>
                         ))}
                     </tbody>
                 </table>
             </div>
+            
+            {/* Mobile Card View */}
+            <div className="md:hidden space-y-4 p-4">
+                {quotations.map((q) => (
+                    <div key={q.id} className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
+                        <div className="flex justify-between items-start mb-2">
+                            <h4 className="text-sm font-semibold text-gray-900">{q.produce_type || q.description}</h4>
+                            <div>{getStatusBadge(q.status)}</div>
+                        </div>
+                        
+                        <div className="text-xs text-gray-500 mb-2" title={userRole === 'seller' ? q.buyer_address : q.seller_address}>
+                             <span className="font-semibold">{userRole === 'seller' ? 'Buyer:' : 'Seller:'}</span> {formatAddress(userRole === 'seller' ? q.buyer_address : q.seller_address)}
+                        </div>
+
+                        <div className="flex justify-between items-center mb-3">
+                            <span className="text-sm font-medium text-gray-700">Amount:</span>
+                            <div className="text-sm font-semibold">
+                                <AmountDisplay maticAmount={q.total_amount} />
+                            </div>
+                        </div>
+
+                        <div className="mt-3 border-t pt-3 flex justify-end">
+                            {renderActions(q)}
+                        </div>
+                    </div>
+                ))}
+            </div>
+
             {quotations.length === 0 && (
                 <div className="text-center py-12 text-gray-500">
                     <p>No quotations found</p>

--- a/frontend/src/components/Dispute/ArbitratorPanel.jsx
+++ b/frontend/src/components/Dispute/ArbitratorPanel.jsx
@@ -46,18 +46,18 @@ const ArbitratorPanel = ({ invoiceId, onResolve }) => {
 
       {error && <p className="text-red-500 text-sm mb-2">{error}</p>}
 
-      <div className="flex space-x-4">
+      <div className="flex flex-col sm:flex-row gap-4">
         <button
           onClick={() => handleResolve('resolved')}
           disabled={loading}
-          className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 disabled:opacity-50 font-medium"
+          className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 disabled:opacity-50 font-medium flex-1 justify-center"
         >
           Resolve (Favor Buyer)
         </button>
         <button
           onClick={() => handleResolve('rejected')}
           disabled={loading}
-          className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 disabled:opacity-50 font-medium"
+          className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 disabled:opacity-50 font-medium flex-1 justify-center"
         >
           Reject (Favor Seller)
         </button>

--- a/frontend/src/components/Financing/FinancingTab.jsx
+++ b/frontend/src/components/Financing/FinancingTab.jsx
@@ -86,16 +86,16 @@ const FinancingTab = ({ invoices, onTokenizeClick }) => {
                 <div className="space-y-4">
                     {eligibleInvoices.length > 0 ? (
                         eligibleInvoices.map(invoice => (
-                            <div key={invoice.invoice_id} className="flex justify-between items-center p-4 border rounded-md">
+                            <div key={invoice.invoice_id} className="flex flex-col md:flex-row justify-between items-start md:items-center p-4 border rounded-md gap-4">
                                 <div>
-                                    <p className="font-semibold">Invoice {invoice.invoice_id.substring(0, 8)}...</p>
-                                    <p className="text-sm text-gray-600">Amount: {invoice.amount} {invoice.currency}</p>
+                                    <p className="font-semibold text-gray-900 break-all">Invoice {invoice.invoice_id.substring(0, 8)}...</p>
+                                    <p className="text-sm text-gray-600">Amount: <span className="font-medium">{invoice.amount} {invoice.currency}</span></p>
                                     <p className="text-sm text-gray-600">Status: <span className="font-medium text-green-600">Deposited in Escrow</span></p>
                                 </div>
                                 <button
                                     onClick={() => onTokenizeClick(invoice)}
                                     disabled={!isFinancingApproved}
-                                    className={`btn-primary ${!isFinancingApproved ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                    className={`btn-primary w-full md:w-auto ${!isFinancingApproved ? 'opacity-50 cursor-not-allowed' : ''}`}
                                 >
                                     Tokenize
                                 </button>
@@ -113,14 +113,16 @@ const FinancingTab = ({ invoices, onTokenizeClick }) => {
                 <div className="space-y-4">
                     {listedInvoices.length > 0 ? (
                         listedInvoices.map(invoice => (
-                            <div key={invoice.invoice_id} className="flex justify-between items-center p-4 border rounded-md bg-gray-50">
-                                <div>
-                                    <p className="font-semibold">Invoice {invoice.invoice_id.substring(0, 8)}...</p>
-                                    <p className="text-sm text-gray-600">Face Value: {invoice.face_value} {invoice.currency}</p>
-                                    <p className="text-sm text-gray-600">Token ID: {invoice.token_id}</p>
-                                    <p className="text-sm text-gray-600">Investor Yield: {invoice.yield_bps ? (invoice.yield_bps / 100).toFixed(2) : '0.00'}%</p>
+                            <div key={invoice.invoice_id} className="flex flex-col md:flex-row justify-between items-start md:items-center p-4 border rounded-md bg-gray-50 gap-4">
+                                <div className="w-full">
+                                    <p className="font-semibold break-all text-gray-900">Invoice {invoice.invoice_id.substring(0, 8)}...</p>
+                                    <div className="grid grid-cols-2 gap-x-4 gap-y-1 mt-1">
+                                        <p className="text-sm text-gray-600">Face Value: <span className="font-medium text-gray-900">{invoice.face_value} {invoice.currency}</span></p>
+                                        <p className="text-sm text-gray-600">Yield: <span className="font-medium text-green-600">{invoice.yield_bps ? (invoice.yield_bps / 100).toFixed(2) : '0.00'}%</span></p>
+                                        <p className="text-col-span-2 text-xs text-gray-400">Token ID: {invoice.token_id}</p>
+                                    </div>
                                 </div>
-                                <span className="text-sm font-medium text-blue-600 px-3 py-1 bg-blue-100 rounded-full">
+                                <span className="text-xs font-semibold text-blue-700 px-3 py-1 bg-blue-100 rounded-full self-start md:self-center">
                                     Listed
                                 </span>
                             </div>

--- a/frontend/src/components/Invoice/InvoiceList.jsx
+++ b/frontend/src/components/Invoice/InvoiceList.jsx
@@ -47,9 +47,43 @@ const InvoiceList = ({
         }
     };
 
+    const renderActions = (invoice) => (
+        <div className="flex flex-wrap gap-2 items-center">
+            {userRole === 'buyer' && invoice.escrow_status === 'created' && (
+                <button onClick={(e) => { e.stopPropagation(); onPayInvoice(invoice); }} className="text-white bg-green-600 hover:bg-green-700 px-3 py-1 rounded-md text-xs">Pay Invoice</button>
+            )}
+            {userRole === 'seller' && invoice.escrow_status === 'deposited' && onConfirmShipment && (
+                <button
+                    onClick={(e) => { e.stopPropagation(); onConfirmShipment(invoice); }}
+                    className="text-purple-600 hover:text-purple-900 text-xs font-semibold"
+                >
+                    Confirm Shipment
+                </button>
+            )}
+            {userRole === 'buyer' && invoice.escrow_status === 'shipped' && (
+                <button onClick={(e) => { e.stopPropagation(); onConfirmRelease(invoice); }} className="text-white bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded-md text-xs">Release Funds</button>
+            )}
+            {['deposited', 'shipped'].includes(invoice.escrow_status) && (
+                <button onClick={(e) => { e.stopPropagation(); onRaiseDispute(invoice); }} className="text-white bg-red-600 hover:bg-red-700 px-3 py-1 rounded-md text-xs">Raise Dispute</button>
+            )}
+            <button 
+                onClick={(e) => { e.stopPropagation(); onShowQRCode(invoice); }} 
+                className="text-white bg-indigo-600 hover:bg-indigo-700 px-3 py-1 rounded-md text-xs flex items-center gap-1"
+                title="View Produce Passport & Tracking"
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-3 h-3">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 013.75 9.375v-4.5zM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 01-1.125-1.125v-4.5zM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0113.5 9.375v-4.5z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 6.75h.75v.75h-.75v-.75zM6.75 16.5h.75v.75h-.75v-.75zM16.5 6.75h.75v.75h-.75v-.75zM13.5 13.5h.75v.75h-.75v-.75zM13.5 19.5h.75v.75h-.75v-.75zM19.5 13.5h.75v.75h-.75v-.75zM19.5 19.5h.75v.75h-.75v-.75zM16.5 16.5h.75v.75h-.75v-.75z" />
+                </svg>
+                View Passport
+            </button>
+        </div>
+    );
+
     return (
         <div className="bg-white rounded-lg shadow-md overflow-hidden">
-            <div className="overflow-x-auto">
+            {/* Desktop Table View */}
+            <div className="hidden md:block overflow-x-auto">
                 <table className="min-w-full divide-y divide-gray-200">
                     <thead className="bg-gray-50">
                         <tr>
@@ -75,41 +109,45 @@ const InvoiceList = ({
                                     <AmountDisplay maticAmount={invoice.amount} />
                                 </td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm">{getStatusChip(invoice.escrow_status)}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-2 flex items-center">
-                                    {userRole === 'buyer' && invoice.escrow_status === 'created' && (
-                                        <button onClick={(e) => { e.stopPropagation(); onPayInvoice(invoice); }} className="text-white bg-green-600 hover:bg-green-700 px-3 py-1 rounded-md text-xs">Pay Invoice</button>
-                                    )}
-                                    {userRole === 'seller' && invoice.escrow_status === 'deposited' && onConfirmShipment && (
-                                        <button
-                                            onClick={() => onConfirmShipment(invoice)}
-                                            className="text-purple-600 hover:text-purple-900"
-                                        >
-                                            Confirm Shipment
-                                        </button>
-                                    )}
-                                    {userRole === 'buyer' && invoice.escrow_status === 'shipped' && (
-                                        <button onClick={(e) => { e.stopPropagation(); onConfirmRelease(invoice); }} className="text-white bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded-md text-xs">Release Funds</button>
-                                    )}
-                                    {['deposited', 'shipped'].includes(invoice.escrow_status) && (
-                                        <button onClick={(e) => { e.stopPropagation(); onRaiseDispute(invoice); }} className="text-white bg-red-600 hover:bg-red-700 px-3 py-1 rounded-md text-xs">Raise Dispute</button>
-                                    )}
-                                    {/* UPDATED: "View Passport" Button */}
-                                    <button 
-                                        onClick={(e) => { e.stopPropagation(); onShowQRCode(invoice); }} 
-                                        className="text-white bg-indigo-600 hover:bg-indigo-700 px-3 py-1 rounded-md text-xs flex items-center gap-1"
-                                        title="View Produce Passport & Tracking"
-                                    >
-                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-3 h-3">
-                                          <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 013.75 9.375v-4.5zM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 01-1.125-1.125v-4.5zM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0113.5 9.375v-4.5z" />
-                                          <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 6.75h.75v.75h-.75v-.75zM6.75 16.5h.75v.75h-.75v-.75zM16.5 6.75h.75v.75h-.75v-.75zM13.5 13.5h.75v.75h-.75v-.75zM13.5 19.5h.75v.75h-.75v-.75zM19.5 13.5h.75v.75h-.75v-.75zM19.5 19.5h.75v.75h-.75v-.75zM16.5 16.5h.75v.75h-.75v-.75z" />
-                                        </svg>
-                                        View Passport
-                                    </button>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                                    {renderActions(invoice)}
                                 </td>
                             </tr>
                         ))}
                     </tbody>
                 </table>
+            </div>
+
+            {/* Mobile Card View */}
+            <div className="md:hidden space-y-4 p-4">
+                {invoices.map((invoice) => (
+                    <div 
+                        key={invoice.invoice_id} 
+                        className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm active:bg-gray-50 transition-colors cursor-pointer"
+                        onClick={() => onSelectInvoice(invoice)}
+                    >
+                        <div className="flex justify-between items-start mb-2">
+                            <div 
+                                className="text-sm font-medium text-gray-900 truncate hover:text-blue-600 hover:underline"
+                                onClick={(e) => copyToClipboard(invoice.invoice_id, e)}
+                            >
+                                #{formatAddress(invoice.invoice_id)}
+                            </div>
+                            <div>{getStatusChip(invoice.escrow_status)}</div>
+                        </div>
+                        
+                        <div className="flex justify-between items-center mb-2">
+                            <div className="text-sm text-gray-500">{invoice.description}</div>
+                            <div className="text-sm font-semibold">
+                                <AmountDisplay maticAmount={invoice.amount} />
+                            </div>
+                        </div>
+
+                        <div className="mt-3 border-t pt-3">
+                            {renderActions(invoice)}
+                        </div>
+                    </div>
+                ))}
             </div>
         </div>
     );

--- a/frontend/src/components/Quotation/BuyerQuotationApproval.jsx
+++ b/frontend/src/components/Quotation/BuyerQuotationApproval.jsx
@@ -62,14 +62,21 @@ const BuyerQuotationApproval = ({ quotations, onApprove, onReject }) => {
                     </p>
                     {/* --- End of update --- */}
 
-                    <p><strong>Seller:</strong> {quotation.seller_address}</p>
-                    <button
-                        onClick={() => onApprove(quotation.id)}
-                        className="bg-blue-500 hover:bg-blue-900 text-white px-4 py-2 rounded mt-2 font-semibold"
-                    >
-                        Approve Quotation
-                    </button>
-                    <button onClick={() => onReject(quotation.id)} className="bg-red-600 hover:bg-red-900 text-white font-semibold ml-2 px-4 py-2 rounded mt-2">Reject Quotation</button>
+                    <p className="break-all"><strong>Seller:</strong> {quotation.seller_address}</p>
+                    <div className="flex flex-wrap gap-2 mt-2">
+                        <button
+                            onClick={() => onApprove(quotation.id)}
+                            className="bg-blue-500 hover:bg-blue-900 text-white px-4 py-2 rounded font-semibold text-sm flex-1 sm:flex-none justify-center"
+                        >
+                            Approve Quotation
+                        </button>
+                        <button 
+                            onClick={() => onReject(quotation.id)} 
+                            className="bg-red-600 hover:bg-red-900 text-white font-semibold px-4 py-2 rounded text-sm flex-1 sm:flex-none justify-center"
+                        >
+                            Reject Quotation
+                        </button>
+                    </div>
                 </div>
             ))}
             {quotations.length === 0 && <p>No pending quotations to approve.</p>}

--- a/frontend/src/components/Register.jsx
+++ b/frontend/src/components/Register.jsx
@@ -108,7 +108,7 @@ const Register = ({ onLogin }) => {
             </div>
 
             <form className="space-y-5" onSubmit={handleSubmit}>
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                   <label htmlFor="firstName" className="block text-sm font-medium text-gray-700 mb-1.5">
                     First name

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -240,7 +240,9 @@ const AdminDashboard = ({ activeTab = 'overview' }) => {
       <div className="px-6 py-4 border-b border-gray-200">
         <h3 className="text-lg font-semibold text-gray-800">User Management</h3>
       </div>
-      <div className="overflow-x-auto">
+      
+      {/* Desktop Table */}
+      <div className="hidden md:block overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
@@ -290,8 +292,55 @@ const AdminDashboard = ({ activeTab = 'overview' }) => {
             ))}
           </tbody>
         </table>
-        {users.length === 0 && <EmptyState message="No users found" />}
       </div>
+
+      {/* Mobile Cards */}
+      <div className="md:hidden p-4 space-y-4">
+        {users.map(user => (
+          <div key={user.id} className="bg-white border rounded-lg p-4 shadow-sm">
+            <div className="flex justify-between items-start mb-2">
+              <span className="font-medium text-gray-900 truncate max-w-[200px]">{user.email}</span>
+              <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
+                  user.kyc_status === 'verified' ? 'bg-green-100 text-green-800' : 
+                  user.kyc_status === 'pending' ? 'bg-yellow-100 text-yellow-800' : 
+                  'bg-red-100 text-red-800'
+                }`}>
+                  {user.kyc_status}
+              </span>
+            </div>
+            
+            <div className="text-xs text-gray-500 font-mono mb-4 break-all">
+              {user.wallet_address}
+            </div>
+
+            <div className="flex flex-col gap-2">
+               <div className="flex justify-between items-center gap-2">
+                  <ActionButton
+                    onClick={() => handleFreezeToggle(user.id, user.is_frozen)}
+                    variant={user.is_frozen ? 'success' : 'danger'}
+                    className="flex-1 text-center justify-center"
+                  >
+                    {user.is_frozen ? 'Unfreeze' : 'Freeze'}
+                  </ActionButton>
+                  
+                  <select 
+                    onChange={(e) => handleUpdateUserRole(user.id, e.target.value)} 
+                    defaultValue={user.role}
+                    className="flex-1 border border-gray-300 rounded px-2 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    aria-label="Change user role"
+                  >
+                    <option value="seller">Seller</option>
+                    <option value="buyer">Buyer</option>
+                    <option value="admin">Admin</option>
+                    <option value="shipment">Shipment</option>
+                  </select>
+               </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      
+      {users.length === 0 && <EmptyState message="No users found" />}
     </div>
   );
 


### PR DESCRIPTION
# Mobile Responsiveness Improvements

## Description
This PR addresses issue #194 by making key components and pages of the FinovatePay dashboard fully mobile-responsive. The changes focus on replacing wide data tables with card-based layouts on smaller screens and adjusting flex containers to prevent overflow.

##  Changes Made

### Components Updated
- **InvoiceList.jsx**: Replaced the desktop-only table view with a responsive card layout for mobile devices.
- **QuotationList.jsx**: Implemented a card-based view for quotations on mobile screens.
- **PaymentHistoryList.jsx**: Added a mobile-friendly view for transaction history.
- **FinancingTab.jsx**: Updated the flex layout to stack elements vertically on mobile, ensuring buttons and text don't overflow.
- **AdminDashboard.jsx**: Converted the User Management table into a responsive card list for admin mobile views.
- **ArbitratorPanel.jsx**: Adjusted button groups to stack vertically on small screens for better usability.
- **BuyerQuotationApproval.jsx**: Improved button wrapping and layout for approval actions on mobile.
- **Register.jsx**: Tweaked the form grid to be single-column on very small devices.

### Responsive Strategy
- Used Tailwind CSS utility classes (`hidden md:block` vs `md:hidden`) to toggle between Table and Card views.
- Applied `flex-col` for mobile and `flex-row` for desktop on action buttons and list items.
- Added truncation and text wrapping (`break-all`, `truncate`) to handle long wallet addresses and IDs on small screens.

## Testing Instructions
1. Checkout this branch: `git checkout fix/mobile-responsiveness`
2. Run the frontend: `cd frontend && npm run dev`
3. Open the application in a browser and toggle the device toolbar (F12 -> Ctrl+Shift+M).
4. Verify that tables (Invoices, Quotations, Users) transform into list cards on screens smaller than 768px.
5. Check that buttons in the Dispute and Financing sections stack correctly without horizontal scrolling.

Closes #194