### PR TITLE
Fix/sidebar stats

### DIFF
--- a/frontend/src/pages/SellerDashboard.jsx
+++ b/frontend/src/pages/SellerDashboard.jsx
@@ -295,7 +295,14 @@ const SellerDashboard = ({ activeTab = 'overview' }) => {
   }, [loadInitialData]);
 
   useEffect(() => {
-    setGlobalStats({ totalInvoices: invoices.length });
+    const activeEscrows = invoices.filter(inv => ['deposited', 'disputed', 'shipped'].includes(inv.escrow_status)).length;
+    const completed = invoices.filter(inv => inv.escrow_status === 'released').length;
+    
+    setGlobalStats({ 
+      totalInvoices: invoices.length,
+      activeEscrows,
+      completed
+    });
   }, [invoices, setGlobalStats]);
 
 


### PR DESCRIPTION
## Fix: Sidebar Quick Stats shows 0 for Everything (#223)

### Description
This PR fixes the issue where the "Quick Stats" section in the Sidebar was displaying 0 for all metrics ("Total Invoices", "Active Escrows", "Completed") for **Seller** and **Investor** roles.

The issue was caused by:
1.  `SellerDashboard` only updating `totalInvoices` and leaving other stats as default (0).
2.  `InvestorDashboard` not updating the global stats context at all.

### Changes Implemented
- **Updated `SellerDashboard.jsx`**:
    - Modified the `useEffect` hook to calculate `activeEscrows` and `completed` counts based on the fetched invoices.
    - Updates `setGlobalStats` with the full set of metrics.
- **Updated `InvestorDashboard.jsx`**:
    - Imported `useStatsActions`.
    - Added logic to sync `marketplaceListings` and `portfolio` data to the global stats context.
    - `Total Invoices` reflects marketplace listings.
    - `Active Escrows` reflects active investments.
    - `Completed` reflects fully redeemed investments.

### Verification
- [x] Verified logic for `Seller` stats calculation.
- [x] Verified logic for `Investor` stats sync.
- [x] Ensured stats update even when landing on the default tab.

### Related Issue
Closes #223