### PR TITLE
Missing Input Validation for _sellerWins in Dispute Resolution

### DIFF
--- a/contracts/EscrowContract.sol
+++ b/contracts/EscrowContract.sol
@@ -301,6 +301,7 @@ contract EscrowContract is
     
     function resolveDispute(bytes32 _invoiceId, bool _sellerWins) external onlyAdmin {
         Escrow storage escrow = escrows[_invoiceId];
+        require(escrow.disputeRaised, "No dispute raised");
         require(escrow.status == EscrowStatus.Disputed, "Not disputed");
         
         _resolveEscrow(_invoiceId, _sellerWins);


### PR DESCRIPTION
Fixed the missing input validation for disputeRaised in the resolveDispute() function.

## Changes made to contracts/EscrowContract.sol:

Added the validation check require(escrow.disputeRaised, "No dispute raised"); at the beginning of the resolveDispute() function.

## Updated function:

```
solidity
function resolveDispute(bytes32 _invoiceId, bool _sellerWins) external onlyAdmin {
    Escrow storage escrow = escrows[_invoiceId];
    require(escrow.disputeRaised, "No dispute raised");  // Added
    require(escrow.status == EscrowStatus.Disputed, "Not disputed");
    
    _resolveEscrow(_invoiceId, _sellerWins);
}
```

closes #299