### PR TITLE
Frontend expects token in localStorage while Backend uses HttpOnly co…

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -18,17 +18,8 @@ export const api = axios.create({
   withCredentials: true,
 });
 
-api.interceptors.request.use((config) => {
-  const token = localStorage.getItem('token');
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
-}, (error) => {
-  return Promise.reject(error);
-});
-
 // Handle API errors with comprehensive error handling
+
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
@@ -88,11 +79,11 @@ api.interceptors.response.use(
         });
         
       case 401:
-        // Clear user data and token from localStorage
+        // Clear user data from localStorage
         localStorage.removeItem('user');
-        localStorage.removeItem('token'); // Add this line
         
         // Use React Router navigation if available, fallback to hard redirect
+
         if (navigateFunction) {
           navigateFunction('/login', { replace: true });
         } else {
@@ -481,6 +472,7 @@ export const getAnalyticsOverview = () => {
   return api.get('/analytics/overview');
 };
 
+export const getInvoiceRisk = (invoiceId) => {
   return api.get(`/analytics/risk/${invoiceId}`);
 };
 


### PR DESCRIPTION
## Changes made to frontend/src/utils/api.js:

Removed the request interceptor that was attempting to read token from localStorage and manually inject it into the Authorization header. This was redundant because:

The backend sets JWT as HttpOnly cookie (not accessible via JavaScript)
withCredentials: true is already configured, so the browser automatically sends the HttpOnly cookie with every request
Updated the 401 error handler to remove localStorage.removeItem('token') since the token is no longer stored in localStorage (it's in the HttpOnly cookie managed by the browser)

Fixed a pre-existing syntax error - added missing getInvoiceRisk function declaration that was causing a TypeScript error


closes #321