### PR TITLE
Fix potential recursive 401 loop in Axios Interceptor

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -18,6 +18,13 @@ export const api = axios.create({
   withCredentials: true,
 });
 
+// Raw axios instance without interceptors for logout requests
+// This prevents recursive 401 loops when logout endpoint also returns 401
+const rawAxios = axios.create({
+  baseURL: API_BASE_URL,
+  withCredentials: true,
+});
+
 // Handle API errors with comprehensive error handling
 
 api.interceptors.response.use(
@@ -79,9 +86,10 @@ api.interceptors.response.use(
         });
         
       case 401:
-        // Call backend logout to clear HttpOnly cookie, then clear localStorage
+        // Call backend logout to clear HttpOnly cookie using raw axios (without interceptor)
+        // to prevent recursive 401 loops if logout endpoint also returns 401
         try {
-          await api.post('/auth/logout');
+          await rawAxios.post('/auth/logout');
         } catch (logoutError) {
           console.error('Logout request failed:', logoutError);
         }


### PR DESCRIPTION
## Changes:

✅ Created a separate [rawAxios](vscode-file://vscode-app/c:/Users/omkar/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instance without interceptors for logout requests
✅ Updated 401 error handler to use [rawAxios.post('/auth/logout')](vscode-file://vscode-app/c:/Users/omkar/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of [api.post()](vscode-file://vscode-app/c:/Users/omkar/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
✅ Added comments explaining the fix to prevent future regressions


## fixes:

Logout uses raw axios without interceptors → No recursive loop even if logout returns 401

closes: #332

@GauravKarakoti  plz review it

