### PR TITLE
Fix ETH transfer gas limit to support smart contract wallets

### DIFF
--- a/contracts/EscrowContract.sol
+++ b/contracts/EscrowContract.sol
@@ -335,7 +335,10 @@ contract EscrowContract is
 
     function _payout(address to, address token, uint256 amount) internal {
         if (token == address(0)) {
-            payable(to).transfer(amount);
+            // Use .call() instead of .transfer() to support smart contract wallets
+            // .transfer() has a 2300 gas limit which fails for contracts with fallback logic
+            (bool success, ) = payable(to).call{value: amount}("");
+            require(success, "ETH transfer failed");
         } else {
             IERC20(token).safeTransfer(to, amount);
         }


### PR DESCRIPTION
Requires understanding of EVM gas mechanics, the difference between .transfer() (2300 gas stipend) and .call() (forwards all gas), reentrancy protection patterns, and ensuring backward compatibility with EOAs while enabling smart contract wallet support. Must maintain security guarantees while changing low-level transfer mechanisms.

This PR fixes a critical limitation where smart contract wallets (multisig, proxies, Gnosis Safe, etc.) cannot receive ETH payouts from escrow due to the 2300 gas limit imposed by .transfer().

Changes:

Replaced payable(to).transfer(amount) with payable(to).call{value: amount}("") in _payout() function
Added explicit success check with revert message "ETH transfer failed"
Maintains reentrancy protection via existing nonReentrant modifiers on public functions
Added inline comments explaining the gas limitation issue
The .call() method forwards all available gas, allowing recipient contracts with fallback/receive functions to execute complex logic (e.g., event emissions, state updates) without hitting the 2300 gas limit. This is the recommended pattern per Consensys best practices and OpenZeppelin guidelines.