### PR TITLE
Fix/native eth dispute resolution

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { toast } from 'sonner';
+import { checkOnlineStatus } from './network';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL;
 console.log("API Base URL:", API_BASE_URL);
@@ -48,8 +49,9 @@ api.interceptors.response.use(
         });
       }
       
-      // Check if user is offline
-      if (!navigator.onLine) {
+      // Check if user is offline using robust connectivity detection
+      const isOnline = await checkOnlineStatus();
+      if (!isOnline) {
         console.error('User is offline');
         const message = 'You are offline. Please check your internet connection.';
         toast.error(message);
@@ -329,6 +331,23 @@ export const raiseDispute = (invoiceId, reason) => {
   return api.post('/payments/escrow/dispute', { invoiceId, reason });
 };
 
+// --- Multi-Signature Escrow API ---
+
+// Add multi-signature approval for an escrow
+export const approveMultiSig = (invoiceId) => {
+  return api.post(`/escrow/${invoiceId}/approve`);
+};
+
+// Get multi-signature approval status for an escrow
+export const getMultiSigApprovals = (invoiceId) => {
+  return api.get(`/escrow/${invoiceId}/approvals`);
+};
+
+// Get full escrow status including multi-sig details
+export const getEscrowStatus = (invoiceId) => {
+  return api.get(`/escrow/${invoiceId}/status`);
+};
+
 // --- KYC API ---
 export const verifyKYC = (userData) => {
   return api.post('/kyc/verify', userData);
@@ -506,5 +525,57 @@ export const getInvoiceRisk = (invoiceId) => {
 
 // Alias for getInvoiceRisk used by AnalyticsDashboard
 export const getRiskScore = getInvoiceRisk;
+
+// --- Insurance API ---
+
+// Get insurance configuration
+export const getInsuranceConfig = () => {
+  return api.get('/insurance/config');
+};
+
+// Calculate premium for given coverage and duration
+export const calculateInsurancePremium = (coverageAmount, durationSeconds) => {
+  return api.get('/insurance/calculate-premium', { params: { coverageAmount, durationSeconds } });
+};
+
+// Purchase insurance for an escrow
+export const purchaseInsurance = (data) => {
+  return api.post('/insurance/purchase', data);
+};
+
+// Get user's insurance policies
+export const getInsurancePolicies = () => {
+  return api.get('/insurance/policies');
+};
+
+// Get specific policy details
+export const getInsurancePolicy = (policyId) => {
+  return api.get(`/insurance/policy/${policyId}`);
+};
+
+// Get insurance policies for an invoice
+export const getInvoiceInsurance = (invoiceId) => {
+  return api.get(`/insurance/invoice/${invoiceId}`);
+};
+
+// File a claim on an insurance policy
+export const fileInsuranceClaim = (data) => {
+  return api.post('/insurance/claim', data);
+};
+
+// Approve a claim (admin only)
+export const approveInsuranceClaim = (data) => {
+  return api.post('/insurance/approve-claim', data);
+};
+
+// Get insurance statistics (admin only)
+export const getInsuranceStats = () => {
+  return api.get('/insurance/stats');
+};
+
+// Get all pending claims (admin only)
+export const getPendingClaims = () => {
+  return api.get('/insurance/claims');
+};
 
 export default api;


### PR DESCRIPTION
## Problem
Native ETH was permanently locked in the EscrowContract when disputes were resolved. The `_resolveEscrow` function directly called `IERC20.safeTransfer()` which fails when the token is address(0) (native ETH), preventing the treasury fee and winner payout.

## Solution
Updated `_resolveEscrow` to use the existing `_payout` internal function that properly handles both native ETH and ERC20 tokens:
- Native ETH: Uses `.call()` for secure transfer
- ERC20: Uses `safeTransfer()` as before

## Changes
- Replaced `IERC20(e.token).safeTransfer(treasury, fee)` with `_payout(treasury, e.token, fee)`
- Replaced `IERC20(e.token).safeTransfer(winner, amount)` with `_payout(winner, e.token, amount)`

## Impact
✅ Dispute resolution now works for native ETH escrows ✅ Prevents permanent fund lock
✅ Maintains backward compatibility with ERC20 tokens

closes: #348

