### PR TITLE
Fix: Deduct platform fees on normal escrow release 

### DIFF
--- a/contracts/EscrowContract.sol
+++ b/contracts/EscrowContract.sol
@@ -391,13 +391,21 @@ contract EscrowContract is
     function _releaseFunds(bytes32 _invoiceId) internal {
         Escrow storage escrow = escrows[_invoiceId];
         
-        IERC20(escrow.token).safeTransfer(escrow.seller, escrow.amount);
+        // Deduct platform fee before transferring to seller
+        uint256 payoutAmount = escrow.amount;
+        if (escrow.feeAmount > 0) {
+            IERC20(escrow.token).safeTransfer(treasury, escrow.feeAmount);
+            emit FeeCollected(_invoiceId, escrow.feeAmount);
+            payoutAmount -= escrow.feeAmount;
+        }
+        
+        IERC20(escrow.token).safeTransfer(escrow.seller, payoutAmount);
         
         if (escrow.rwaNftContract != address(0)) {
             IERC721(escrow.rwaNftContract).safeTransferFrom(address(this), escrow.buyer, escrow.rwaTokenId);
         }
         
-        emit EscrowReleased(_invoiceId, escrow.amount);
+        emit EscrowReleased(_invoiceId, payoutAmount);
     }
 
 


### PR DESCRIPTION
## Problem
Platform fees were being bypassed on the normal "happy path" release. When funds were released via confirmRelease → _releaseFunds, the entire escrow amount was transferred to the seller without deducting the platform fee. Fees were only deducted during dispute resolution.

## Solution
Applied the same fee deduction logic from _resolveEscrow to _releaseFunds:
- Deduct platform fee from escrow amount before payout
- Transfer fee to treasury
- Emit FeeCollected event for audit trail
- Update EscrowReleased event to reflect actual payout (after fee)


Fixes #402

@GauravKarakoti  plz review it 