### PR TITLE
Fix: Clean up dispute voting state on escrow resolution

### DIFF
--- a/contracts/EscrowContract.sol
+++ b/contracts/EscrowContract.sol
@@ -667,6 +667,8 @@ contract EscrowContract is
         // Transfer NFT to winner
         _transferNFT(address(this), sellerWins ? buyer : seller, e);
 
+        // Clean up state for gas refund
         delete escrows[invoiceId];
+        delete disputeVotings[invoiceId];
     }
 }


### PR DESCRIPTION
## Problem
When a dispute is resolved via _resolveEscrow, the escrows mapping is deleted but the associated disputeVotings state data persists on-chain, causing unnecessary storage bloat and gas inefficiency.

## Solution
Added deletion of disputeVotings[invoiceId] at the end of _resolveEscrow to ensure complete state cleanup alongside escrow deletion.

## Impact
Reduces contract storage bloat and provides better gas refunds to users who participate in dispute resolution.

Fixes #404

@GauravKarakoti  plz review it 