### PR TITLE
Fix: Replace unsafe .transfer() with .call() in reclaimExpiredFunds

### DIFF
--- a/contracts/EscrowContract.sol
+++ b/contracts/EscrowContract.sol
@@ -336,7 +336,10 @@ contract EscrowContract is
         
         // Return funds to buyer
         if (token == address(0)) {
-            payable(buyer).transfer(reclaimAmount);
+            // Use .call() instead of .transfer() to support smart contract wallets
+            // .transfer() has a 2300 gas limit which fails for contracts with fallback logic
+            (bool success, ) = payable(buyer).call{value: reclaimAmount}("");
+            require(success, "ETH transfer failed");
         } else {
             IERC20(token).safeTransfer(buyer, reclaimAmount);
         }


### PR DESCRIPTION
**Problem:**
- reclaimExpiredFunds() used .transfer() which has a 2300 gas limit
- This causes transactions to fail if the buyer is a smart contract (multi-sig, AA wallet, etc.)
- The _payout() function already correctly uses .call() for ETH transfers

**Solution:**
- Replace payable(buyer).transfer(reclaimAmount) with (bool success, ) = payable(buyer).call{value: reclaimAmount}("")
- Added success check to ensure the ETH transfer completes
- Maintains consistency with the existing _payout() pattern throughout the codebase

**Fixes:** #415

@GauravKarakoti  plz review it 