### PR TITLE
fix: replace Date.now() with ethers.randomBytes(32) in generateAuctio…

### DIFF
--- a/backend/services/auctionService.js
+++ b/backend/services/auctionService.js
@@ -88,8 +88,8 @@ const statusToString = (status) => {
 const generateAuctionId = (invoiceId, sellerAddress) => {
   return ethers.keccak256(
     ethers.solidityPacked(
-      ['bytes32', 'address', 'uint256'],
-      [invoiceId, sellerAddress, Date.now()]
+      ['bytes32', 'address', 'bytes32'],
+      [invoiceId, sellerAddress, ethers.randomBytes(32)]
     )
   );
 };


### PR DESCRIPTION



**What was done:**
- **File:** [auctionService.js](file:///d:\FinovotePay\FinovatePay\backend\services\auctionService.js) (lines 88–95)
- **Change:** Replaced `['bytes32', 'address', 'uint256']` + `Date.now()` with `['bytes32', 'address', 'bytes32']` + `ethers.randomBytes(32)` — eliminating the race condition by using a cryptographically secure random value instead of a timestamp.
- **Branch:** `fix/auction-id-race-condition` created and committed.
