### PR TITLE
fix: race condition in bidId generation and pool import in relayerSer…

### DIFF
--- a/backend/services/auctionService.js
+++ b/backend/services/auctionService.js
@@ -354,11 +354,11 @@ const getAuctionBids = async (auctionId) => {
 const placeBid = async (bidData) => {
   const { auctionId, bidderAddress, yieldBps, bidAmount, txHash } = bidData;
 
-  // Generate bid ID
+  // Generate bid ID with random salt to prevent race condition collisions
   const bidId = ethers.keccak256(
     ethers.solidityPacked(
-      ['bytes32', 'address', 'uint256'],
-      [auctionId, bidderAddress, Date.now()]
+      ['bytes32', 'address', 'bytes32'],
+      [auctionId, bidderAddress, ethers.randomBytes(32)]
     )
   );
 

--- a/backend/services/relayerService.js
+++ b/backend/services/relayerService.js
@@ -166,7 +166,7 @@ class RelayerService {
       const maticUsdPrice = 0.50; // Placeholder
       const gasCostUsd = gasCostMatic * maticUsdPrice;
 
-      const pool = require('../config/database');
+      const { pool } = require('../config/database');
       await pool.query(
         `INSERT INTO meta_transactions 
          (user_id, tx_hash, from_address, to_address, gas_used, gas_price, gas_cost_matic, gas_cost_usd, status, confirmed_at)


### PR DESCRIPTION
I'll fix both bugs. Let me first read the relevant files to understand the full context.
I've identified both bugs. Let me create a task list and fix them.
Now let me fix both bugs:
Now let me commit and push the changes:
The push failed due to repository permissions. Let me update the status:
Both bugs have been fixed and committed locally:

**Changes made:**

1. **[auctionService.js](backend/services/auctionService.js#L358-L363)** - Fixed the `bidId` race condition by using `ethers.randomBytes(32)` instead of `Date.now()`:
   - Before: `['bytes32', 'address', 'uint256']` with `Date.now()`
   - After: `['bytes32', 'address', 'bytes32']` with `ethers.randomBytes(32)`
   - This matches the same fix pattern already applied to `generateAuctionId`

2. **[relayerService.js](backend/services/relayerService.js#L169)** - Fixed the pool import:
   - Before: `const pool = require('../config/database')`
   - After: `const { pool } = require('../config/database')`

