### PR TITLE
Security: Replace unsafe .transfer() with .call() for ETH transfers

### DIFF
--- a/contracts/EscrowContract.sol
+++ b/contracts/EscrowContract.sol
@@ -336,7 +336,10 @@ contract EscrowContract is
         
         // Return funds to buyer
         if (token == address(0)) {
-            payable(buyer).transfer(reclaimAmount);
+            // Use .call() instead of .transfer() to support smart contract wallets
+            // .transfer() has a 2300 gas limit which fails for contracts with fallback logic
+            (bool success, ) = payable(buyer).call{value: reclaimAmount}("");
+            require(success, "ETH transfer failed");
         } else {
             IERC20(token).safeTransfer(buyer, reclaimAmount);
         }


### PR DESCRIPTION
## Security Fix: Replace .transfer() with .call() for ETH transfers

### Issue
Fixed critical vulnerability where `.transfer()` was used for ETH transfers with a 2300 gas stipend limitation, causing transactions to fail when:
- Interacting with smart contract wallets
- Sending to contracts with complex fallback logic
- Handling EOAs with pre-contract logic

### Changes
- **File:** `contracts/EscrowContract.sol`
- **Location:** Line 339 - `claimRefundAfterExpiry()` function
- **Change:** Replaced `payable(buyer).transfer(reclaimAmount)` with `.call{value: amount}("")` pattern

### Security Benefits
✅ Better gas flexibility - No 2300 gas limit restriction ✅ Improved compatibility with smart contract wallets ✅ Maintains CEI (Checks-Effects-Interactions) pattern ✅ Enhances overall contract security and reliability


closes: #466 

@GauravKarakoti  plz review it 