### PR TITLE
security: enforce mandatory webhook signature verification

### DIFF
--- a/backend/routes/fiatRamp.js
+++ b/backend/routes/fiatRamp.js
@@ -122,31 +122,53 @@ router.post('/create-link', requireRole(['buyer', 'seller', 'investor', 'admin']
 /**
  * POST /api/fiat-ramp/webhook
  * Handle MoonPay webhook callbacks for payment confirmation
+ * SECURITY: Requires mandatory signature verification
  */
 router.post('/webhook', async (req, res) => {
     try {
         const webhookData = req.body;
         const signature = req.headers['x-moonpay-signature'];
-
-        // Verify webhook signature (in production)
         const moonpayWebhookKey = process.env.MOONPAY_WEBHOOK_KEY;
-        
-        if (moonpayWebhookKey && signature) {
-            const crypto = require('crypto');
-            const expectedSignature = crypto
-                .createHmac('sha256', moonpayWebhookKey)
-                .update(JSON.stringify(webhookData))
-                .digest('hex');
 
-            if (signature !== expectedSignature) {
-                console.warn('Invalid MoonPay webhook signature');
-                return res.status(401).json({ error: 'Invalid signature' });
-            }
+        // MANDATORY signature verification - reject if not configured
+        if (!moonpayWebhookKey) {
+            console.error('SECURITY: MOONPAY_WEBHOOK_KEY not configured - rejecting webhook');
+            return res.status(500).json({ 
+                error: 'Webhook verification not configured',
+                message: 'Server configuration error - contact administrator'
+            });
         }
 
+        // Reject webhooks without signature
+        if (!signature) {
+            console.warn('SECURITY: Webhook received without signature header');
+            return res.status(401).json({ 
+                error: 'Missing signature',
+                message: 'x-moonpay-signature header is required'
+            });
+        }
+
+        // Verify webhook signature
+        const crypto = require('crypto');
+        const expectedSignature = crypto
+            .createHmac('sha256', moonpayWebhookKey)
+            .update(JSON.stringify(webhookData))
+            .digest('hex');
+
+        if (signature !== expectedSignature) {
+            console.warn('SECURITY: Invalid MoonPay webhook signature detected');
+            console.warn(`Expected: ${expectedSignature.substring(0, 10)}...`);
+            console.warn(`Received: ${signature.substring(0, 10)}...`);
+            return res.status(401).json({ 
+                error: 'Invalid signature',
+                message: 'Webhook signature verification failed'
+            });
+        }
+
+        // Signature verified - process webhook
         const { type, data } = webhookData;
 
-        console.log(`MoonPay webhook received: ${type}`, data);
+        console.log(`MoonPay webhook received (verified): ${type}`, data);
 
         switch (type) {
             case 'payment.created':


### PR DESCRIPTION
Securing webhook endpoints requires understanding the attack surface of payment integrations. The previous implementation only verified signatures when both the webhook key and signature were present, creating a critical vulnerability where missing configuration would silently accept forged webhooks. Attackers could exploit this to inject fake payment confirmations, manipulate transaction states, and potentially steal funds. The challenge is enforcing verification without breaking legitimate webhooks while providing clear error messages for misconfiguration.

Implemented mandatory webhook signature verification for MoonPay payment callbacks. Added three-layer validation: first checks if MOONPAY_WEBHOOK_KEY is configured (returns 500 if missing), then verifies x-moonpay-signature header is present (returns 401 if missing), finally validates the HMAC-SHA256 signature matches expected value (returns 401 if invalid). Enhanced security logging with SECURITY prefix for monitoring and debugging. All webhooks are now rejected unless they pass complete signature verification, preventing payment fraud regardless of environment configuration.

Security improvements:
✅ Mandatory webhook key configuration check (prevents silent bypass)
✅ Required signature header validation (rejects unsigned requests)
✅ HMAC-SHA256 signature verification (prevents forgery)
✅ Enhanced security logging for monitoring attacks
✅ Clear error messages for debugging without exposing secrets
✅ Prevents payment confirmation forgery attacks
✅ Protects against transaction state manipulation

Changes:
- Made MOONPAY_WEBHOOK_KEY check mandatory (returns 500 if not configured)
- Added signature header requirement (returns 401 if missing)
- Enhanced signature verification with detailed logging
- Added security event logging with SECURITY prefix
- Improved error messages for different failure scenarios
- Logs partial signatures for debugging (first 10 chars only)
- Removed conditional verification logic that allowed bypass
done with #485 