### PR TITLE
fix: use requireRole middleware consistently for admin endpoints

### DIFF
--- a/backend/routes/kyc.js
+++ b/backend/routes/kyc.js
@@ -47,18 +47,8 @@ router.get('/status', authenticateToken, async (req, res) => {
 });
 
 // Get all KYC verifications (admin only)
-router.get('/admin/verifications', authenticateToken, async (req, res) => {
+router.get('/admin/verifications', authenticateToken, requireRole(['admin']), async (req, res) => {
   try {
-    // Check if user is admin
-    const userResult = await pool.query(
-      'SELECT role FROM users WHERE id = $1',
-      [req.user.id]
-    );
-
-    if (userResult.rows[0].role !== 'admin') {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
     const verifications = await pool.query(
       `SELECT kv.*, u.email, u.wallet_address, u.company_name 
        FROM kyc_verifications kv
@@ -74,20 +64,10 @@ router.get('/admin/verifications', authenticateToken, async (req, res) => {
 });
 
 // Manual KYC override (admin only)
-router.post('/admin/override', authenticateToken, validateKYCOverride, async (req, res) => {
+router.post('/admin/override', authenticateToken, requireRole(['admin']), validateKYCOverride, async (req, res) => {
   const { user_id, status, risk_level, reason } = req.body;
 
   try {
-    // Check if user is admin
-    const userResult = await pool.query(
-      'SELECT role FROM users WHERE id = $1',
-      [req.user.id]
-    );
-
-    if (userResult.rows[0].role !== 'admin') {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
-
     // Create manual verification record
     await pool.query(
       `INSERT INTO kyc_verifications 


### PR DESCRIPTION
Fixed issue #520.

What was changed:

Replaced manual role checking in /admin/verifications endpoint with requireRole(['admin']) middleware
Updated /admin/override endpoint to use requireRole(['admin']) middleware instead of manual checking
Removed redundant database queries that were fetching user roles manually
Reduced code by 20 lines while improving security consistency
This ensures all admin endpoints use the same authorization pattern, preventing potential bypass vulnerabilities if manual checks are accidentally removed during refactoring.
