### PR TITLE
fix: block disposable email addresses during registration

### DIFF
--- a/backend/middleware/validators.js
+++ b/backend/middleware/validators.js
@@ -44,6 +44,36 @@ const isOTP = (value) => {
 };
 
 /**
+ * Disposable Email Domain Blacklist
+ * Common temporary/disposable email services that should be blocked
+ * for financial platforms requiring verified user contact information
+ */
+const DISPOSABLE_EMAIL_DOMAINS = [
+  // Popular disposable email services
+  'mailinator.com', 'guerrillamail.com', 'temp-mail.org', 'throwaway.email',
+  '10minutemail.com', 'tempmail.com', 'fakeinbox.com', 'trashmail.com',
+  'yopmail.com', 'maildrop.cc', 'getnada.com', 'sharklasers.com',
+  'guerrillamailblock.com', 'pokemail.net', 'spam4.me', 'grr.la',
+  'mailnesia.com', 'mintemail.com', 'mytemp.email', 'tempinbox.com',
+  'dispostable.com', 'emailondeck.com', 'mohmal.com', 'anonbox.net',
+  'burnermail.io', 'mailsac.com', 'mailcatch.com', 'getairmail.com',
+  'guerrillamail.net', 'guerrillamail.org', 'guerrillamail.biz',
+  'spam.la', 'tmpeml.info', 'mailforspam.com', 'anonymbox.com',
+  'throwawaymail.com', 'tempmail.net', 'fakemailgenerator.com',
+  'mailtemp.info', 'emailfake.com', 'tempmailo.com', 'tempr.email',
+  'disposablemail.com', 'throwam.com', 'spambox.us', 'mailexpire.com'
+];
+
+/**
+ * Check if email domain is disposable/temporary
+ */
+const isDisposableEmail = (email) => {
+  if (!email) return false;
+  const domain = email.toLowerCase().split('@')[1];
+  return DISPOSABLE_EMAIL_DOMAINS.includes(domain);
+};
+
+/**
  * AUTH VALIDATORS
  */
 const validateRegister = [
@@ -51,7 +81,13 @@ const validateRegister = [
     .trim()
     .isEmail().withMessage('Invalid email format')
     .normalizeEmail()
-    .isLength({ max: 255 }).withMessage('Email too long'),
+    .isLength({ max: 255 }).withMessage('Email too long')
+    .custom((value) => {
+      if (isDisposableEmail(value)) {
+        throw new Error('Disposable email addresses are not allowed. Please use a permanent email address.');
+      }
+      return true;
+    }),
   
   body('password')
     .isLength({ min: 8 }).withMessage('Password must be at least 8 characters')


### PR DESCRIPTION
Fixed issue #522.

What was changed:

Added disposable email blacklist: Created a comprehensive list of 40+ known disposable/temporary email domains
Implemented validation function: Added isDisposableEmail() to check if an email domain is in the blacklist
Updated registration validator: Added custom validation to reject disposable emails with clear error message
Improved security: Prevents users from registering with throwaway emails, ensuring reliable contact for KYC, disputes, and security notifications
This protects the financial platform by ensuring users provide permanent, verifiable email addresses required for compliance and security communications.