### PR TITLE
feat: Add pagination support to all list endpoints

### DIFF
--- a/backend/controllers/adminController.js
+++ b/backend/controllers/adminController.js
@@ -50,10 +50,24 @@ exports.setInvoiceSpread = async (req, res) => {
 ====================================================== */
 exports.getAllUsers = async (req, res) => {
   try {
+    const { getPaginationParams, getPaginationMetadata } = require('../utils/pagination');
+    const { limit, offset } = getPaginationParams(req.query);
+    
+    // Get total count
+    const countResult = await pool.query('SELECT COUNT(*) as total FROM users');
+    const total = parseInt(countResult.rows[0]?.total || 0);
+    
+    // Get paginated data
     const result = await pool.query(
-      'SELECT id, email, wallet_address, role, kyc_status, is_frozen FROM users ORDER BY created_at DESC'
+      'SELECT id, email, wallet_address, role, kyc_status, is_frozen FROM users ORDER BY created_at DESC LIMIT $1 OFFSET $2',
+      [limit, offset]
     );
-    res.json({ success: true, data: result.rows });
+    
+    res.json({
+      success: true,
+      data: result.rows,
+      pagination: getPaginationMetadata(limit, offset, total)
+    });
   } catch (error) {
     console.error(error);
     return errorResponse(res, error.message, 500);
@@ -249,8 +263,24 @@ exports.updateUserRole = async (req, res) => {
 ====================================================== */
 exports.getInvoices = async (req, res) => {
   try {
-    const result = await pool.query('SELECT * FROM invoices ORDER BY created_at DESC');
-    res.json({ success: true, data: result.rows });
+    const { getPaginationParams, getPaginationMetadata } = require('../utils/pagination');
+    const { limit, offset } = getPaginationParams(req.query);
+    
+    // Get total count
+    const countResult = await pool.query('SELECT COUNT(*) as total FROM invoices');
+    const total = parseInt(countResult.rows[0]?.total || 0);
+    
+    // Get paginated data
+    const result = await pool.query(
+      'SELECT * FROM invoices ORDER BY created_at DESC LIMIT $1 OFFSET $2',
+      [limit, offset]
+    );
+    
+    res.json({
+      success: true,
+      data: result.rows,
+      pagination: getPaginationMetadata(limit, offset, total)
+    });
   } catch (error) {
     console.error(error);
     return errorResponse(res, error.message, 500);

--- a/backend/controllers/disputeController.js
+++ b/backend/controllers/disputeController.js
@@ -118,8 +118,27 @@ exports.uploadEvidence = async (req, res) => {
 exports.getEvidence = async (req, res) => {
   const { invoiceId } = req.params;
   try {
-    const result = await pool.query('SELECT * FROM dispute_evidence WHERE invoice_id = $1 ORDER BY created_at DESC', [invoiceId]);
-    res.json(result.rows);
+    const { getPaginationParams, getPaginationMetadata } = require('../utils/pagination');
+    const { limit, offset } = getPaginationParams(req.query);
+    
+    // Get total count
+    const countResult = await pool.query(
+      'SELECT COUNT(*) as total FROM dispute_evidence WHERE invoice_id = $1',
+      [invoiceId]
+    );
+    const total = parseInt(countResult.rows[0]?.total || 0);
+    
+    // Get paginated data
+    const result = await pool.query(
+      'SELECT * FROM dispute_evidence WHERE invoice_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3',
+      [invoiceId, limit, offset]
+    );
+    
+    res.json({
+      success: true,
+      data: result.rows,
+      pagination: getPaginationMetadata(limit, offset, total)
+    });
   } catch (err) {
     console.error('Error fetching evidence:', err);
     return errorResponse(res, err, 500);
@@ -129,8 +148,27 @@ exports.getEvidence = async (req, res) => {
 exports.getLogs = async (req, res) => {
   const { invoiceId } = req.params;
   try {
-    const result = await pool.query('SELECT * FROM dispute_logs WHERE invoice_id = $1 ORDER BY timestamp ASC', [invoiceId]);
-    res.json(result.rows);
+    const { getPaginationParams, getPaginationMetadata } = require('../utils/pagination');
+    const { limit, offset } = getPaginationParams(req.query);
+    
+    // Get total count
+    const countResult = await pool.query(
+      'SELECT COUNT(*) as total FROM dispute_logs WHERE invoice_id = $1',
+      [invoiceId]
+    );
+    const total = parseInt(countResult.rows[0]?.total || 0);
+    
+    // Get paginated data
+    const result = await pool.query(
+      'SELECT * FROM dispute_logs WHERE invoice_id = $1 ORDER BY timestamp ASC LIMIT $2 OFFSET $3',
+      [invoiceId, limit, offset]
+    );
+    
+    res.json({
+      success: true,
+      data: result.rows,
+      pagination: getPaginationMetadata(limit, offset, total)
+    });
   } catch (err) {
     console.error('Error fetching logs:', err);
     return errorResponse(res, err, 500);

--- a/backend/controllers/produceController.js
+++ b/backend/controllers/produceController.js
@@ -124,14 +124,32 @@ exports.getProduceLot = async (req, res) => {
 
 exports.getSellerLots = async (req, res) => {
   try {
+    const { getPaginationParams, getPaginationMetadata } = require('../utils/pagination');
     const seller_address = req.user.wallet_address;
+    const { limit, offset } = getPaginationParams(req.query);
+    
+    // Count total seller lots
+    const countQuery = `
+      SELECT COUNT(*) as total FROM produce_lots 
+      WHERE farmer_address = $1 AND current_quantity > 0
+    `;
+    const countResult = await pool.query(countQuery, [seller_address]);
+    const total = parseInt(countResult.rows[0]?.total || 0);
+    
+    // Get paginated lots
     const query = `
       SELECT * FROM produce_lots 
       WHERE farmer_address = $1 AND current_quantity > 0
       ORDER BY created_at DESC
+      LIMIT $2 OFFSET $3
     `;
-    const result = await pool.query(query, [seller_address]);
-    res.json(result.rows);
+    const result = await pool.query(query, [seller_address, limit, offset]);
+    
+    res.json({
+      success: true,
+      data: result.rows,
+      pagination: getPaginationMetadata(limit, offset, total)
+    });
   } catch (error) {
     console.error('Error fetching seller lots:', error);
     return errorResponse(res, 'Failed to fetch seller lots.', 500);

--- a/backend/controllers/quotationController.js
+++ b/backend/controllers/quotationController.js
@@ -188,22 +188,35 @@ exports.buyerApproveQuotation = asyncHandler(async (req, res) => {
 
 // ---------------- GET USER QUOTATIONS ----------------
 exports.getQuotations = asyncHandler(async (req, res) => {
+  const { getPaginationParams, getPaginationMetadata } = require('../utils/pagination');
   const userAddress = req.user.wallet_address;
+  const { limit, offset } = getPaginationParams(req.query);
 
+  // Count total quotations
+  const countQuery = `
+    SELECT COUNT(*) as total
+    FROM quotations q
+    WHERE q.seller_address = $1 OR q.buyer_address = $1
+  `;
+  const countResult = await pool.query(countQuery, [userAddress]);
+  const total = parseInt(countResult.rows[0]?.total || 0);
+
+  // Get paginated quotations
   const query = `
     SELECT q.*, p.produce_type
     FROM quotations q
     LEFT JOIN produce_lots p ON q.lot_id = p.lot_id
     WHERE q.seller_address = $1 OR q.buyer_address = $1
     ORDER BY q.created_at DESC
+    LIMIT $2 OFFSET $3
   `;
 
-  const result = await pool.query(query, [userAddress]);
-
+  const result = await pool.query(query, [userAddress, limit, offset]);
 
   res.json({
     success: true,
     data: result.rows,
+    pagination: getPaginationMetadata(limit, offset, total)
   });
 });
 
@@ -239,8 +252,21 @@ exports.rejectQuotation = asyncHandler(async (req, res) => {
 
 // ---------------- PENDING BUYER APPROVALS ----------------
 exports.getPendingBuyerApprovals = asyncHandler(async (req, res) => {
+  const { getPaginationParams, getPaginationMetadata } = require('../utils/pagination');
   const buyerAddress = req.user.wallet_address;
+  const { limit, offset } = getPaginationParams(req.query);
 
+  // Count total pending approvals
+  const countQuery = `
+    SELECT COUNT(*) as total
+    FROM quotations q
+    WHERE q.buyer_address = $1
+      AND q.status = 'pending_buyer_approval'
+  `;
+  const countResult = await pool.query(countQuery, [buyerAddress]);
+  const total = parseInt(countResult.rows[0]?.total || 0);
+
+  // Get paginated pending approvals
   const query = `
     SELECT 
       q.*,
@@ -252,13 +278,14 @@ exports.getPendingBuyerApprovals = asyncHandler(async (req, res) => {
     WHERE q.buyer_address = $1
       AND q.status = 'pending_buyer_approval'
     ORDER BY q.created_at DESC
+    LIMIT $2 OFFSET $3
   `;
 
-  const result = await pool.query(query, [buyerAddress]);
-
+  const result = await pool.query(query, [buyerAddress, limit, offset]);
 
   res.json({
     success: true,
     data: result.rows,
+    pagination: getPaginationMetadata(limit, offset, total)
   });
 });

--- a/backend/controllers/streamingController.js
+++ b/backend/controllers/streamingController.js
@@ -325,8 +325,20 @@ exports.getStream = async (req, res) => {
  */
 exports.getSellerStreams = async (req, res) => {
   try {
+    const { getPaginationParams, getPaginationMetadata } = require('../utils/pagination');
+    const { limit, offset } = getPaginationParams(req.query);
+    
     const streams = await StreamingPayment.findBySeller(req.user.wallet_address);
-    res.json(streams);
+    const total = streams.length;
+    
+    // Apply pagination
+    const paginatedStreams = streams.slice(offset, offset + limit);
+    
+    res.json({
+      success: true,
+      data: paginatedStreams,
+      pagination: getPaginationMetadata(limit, offset, total)
+    });
   } catch (error) {
     console.error('Error getting seller streams:', error);
     return errorResponse(res, error, 500);
@@ -338,8 +350,20 @@ exports.getSellerStreams = async (req, res) => {
  */
 exports.getBuyerStreams = async (req, res) => {
   try {
+    const { getPaginationParams, getPaginationMetadata } = require('../utils/pagination');
+    const { limit, offset } = getPaginationParams(req.query);
+    
     const streams = await StreamingPayment.findByBuyer(req.user.wallet_address);
-    res.json(streams);
+    const total = streams.length;
+    
+    // Apply pagination
+    const paginatedStreams = streams.slice(offset, offset + limit);
+    
+    res.json({
+      success: true,
+      data: paginatedStreams,
+      pagination: getPaginationMetadata(limit, offset, total)
+    });
   } catch (error) {
     console.error('Error getting buyer streams:', error);
     return errorResponse(res, error, 500);
@@ -351,6 +375,8 @@ exports.getBuyerStreams = async (req, res) => {
  */
 exports.getMyStreams = async (req, res) => {
   try {
+    const { getPaginationParams, getPaginationMetadata } = require('../utils/pagination');
+    const { limit, offset } = getPaginationParams(req.query);
     const address = req.user.wallet_address;
     
     const [asSeller, asBuyer] = await Promise.all([
@@ -368,7 +394,16 @@ exports.getMyStreams = async (req, res) => {
       new Map(allStreams.map(s => [s.stream_id, s])).values()
     );
     
-    res.json(uniqueStreams);
+    const total = uniqueStreams.length;
+    
+    // Apply pagination
+    const paginatedStreams = uniqueStreams.slice(offset, offset + limit);
+    
+    res.json({
+      success: true,
+      data: paginatedStreams,
+      pagination: getPaginationMetadata(limit, offset, total)
+    });
   } catch (error) {
     console.error('Error getting my streams:', error);
     return errorResponse(res, error, 500);

--- a/backend/utils/pagination.js
+++ b/backend/utils/pagination.js
@@ -1,0 +1,170 @@
+/**
+ * Pagination Utility
+ * 
+ * Provides pagination helpers for list endpoints:
+ * - Offset-based pagination (limit, offset)
+ * - Cursor-based pagination (cursor, limit)
+ * - Total count calculation
+ * 
+ * Usage:
+ * const { limit, offset, cursor } = getPaginationParams(req.query);
+ * const { rows: data, totalCount } = await getPaginatedData(pool, sql, params);
+ * res.json({
+ *   success: true,
+ *   data,
+ *   pagination: getPaginationMetadata(limit, offset, totalCount)
+ * });
+ */
+
+/**
+ * Extract pagination parameters from query string
+ * 
+ * @param {object} query - req.query object
+ * @returns {object} { limit, offset, page, cursor }
+ */
+function getPaginationParams(query) {
+  const DEFAULT_LIMIT = 50;
+  const MAX_LIMIT = 500;
+  const DEFAULT_PAGE = 1;
+
+  // Parse limit and enforce max
+  let limit = parseInt(query.limit) || DEFAULT_LIMIT;
+  limit = Math.min(limit, MAX_LIMIT);
+  limit = Math.max(limit, 1); // Minimum 1 record
+
+  // Parse offset
+  let offset = parseInt(query.offset) || 0;
+  offset = Math.max(offset, 0); // No negative offsets
+
+  // Parse page (for convenience - converts to offset)
+  const page = parseInt(query.page) || DEFAULT_PAGE;
+  if (query.page) {
+    offset = (page - 1) * limit;
+  }
+
+  // Parse cursor (for cursor-based pagination)
+  const cursor = query.cursor || null;
+
+  return {
+    limit,
+    offset,
+    page: Math.ceil(offset / limit) + 1,
+    cursor
+  };
+}
+
+/**
+ * Build SQL LIMIT/OFFSET clause
+ * 
+ * @param {number} limit - Records per page
+ * @param {number} offset - Records to skip
+ * @returns {string} SQL clause
+ */
+function getLimitOffsetClause(limit, offset) {
+  return `LIMIT ${limit} OFFSET ${offset}`;
+}
+
+/**
+ * Execute paginated query with total count
+ * 
+ * @param {pool} pool - PostgreSQL connection pool
+ * @param {string} baseQuery - SQL query (without LIMIT/OFFSET)
+ * @param {array} params - Query parameters
+ * @param {number} limit - Records per page
+ * @param {number} offset - Records to skip
+ * @returns {Promise} { rows, total, limit, offset }
+ */
+async function getPaginatedData(pool, baseQuery, params = [], limit = 50, offset = 0) {
+  try {
+    // Execute data query with pagination
+    const dataQuery = `${baseQuery} LIMIT $${params.length + 1} OFFSET $${params.length + 2}`;
+    const dataResult = await pool.query(dataQuery, [...params, limit, offset]);
+
+    // Execute count query
+    const countRegex = /SELECT\s+[\s\S]*?\s+FROM\s+/i;
+    const countQuery = baseQuery.replace(countRegex, 'SELECT COUNT(*) as total FROM');
+    // Remove LIMIT/OFFSET from count query if present
+    const cleanCountQuery = countQuery.replace(/LIMIT\s+\d+(\s+OFFSET\s+\d+)?/i, '').trim();
+    const countResult = await pool.query(cleanCountQuery, params);
+
+    const total = parseInt(countResult.rows[0]?.total || 0);
+
+    return {
+      rows: dataResult.rows,
+      total,
+      limit,
+      offset,
+      page: Math.ceil(offset / limit) + 1,
+      totalPages: Math.ceil(total / limit)
+    };
+  } catch (error) {
+    console.error('Pagination query error:', error);
+    throw error;
+  }
+}
+
+/**
+ * Build pagination metadata for response
+ * 
+ * @param {number} limit - Records per page
+ * @param {number} offset - Records skipped
+ * @param {number} total - Total record count
+ * @returns {object} Pagination metadata
+ */
+function getPaginationMetadata(limit, offset, total) {
+  const page = Math.ceil(offset / limit) + 1;
+  const totalPages = Math.ceil(total / limit);
+  const hasNextPage = page < totalPages;
+  const hasPreviousPage = page > 1;
+
+  return {
+    limit,
+    offset,
+    page,
+    total,
+    totalPages,
+    hasNextPage,
+    hasPreviousPage,
+    pageSize: limit,
+    remaining: Math.max(0, total - (offset + limit))
+  };
+}
+
+/**
+ * Validate pagination parameters
+ * 
+ * @param {number} limit - Records per page
+ * @param {number} offset - Records to skip
+ * @returns {array} Array of error messages (empty if valid)
+ */
+function validatePaginationParams(limit, offset) {
+  const errors = [];
+
+  if (limit < 1) errors.push('Limit must be at least 1');
+  if (limit > 500) errors.push('Limit cannot exceed 500');
+  if (offset < 0) errors.push('Offset cannot be negative');
+
+  return errors;
+}
+
+/**
+ * Build cursor-based pagination clause
+ * Uses an ID or timestamp as cursor
+ * 
+ * @param {string} cursor - Cursor value
+ * @param {string} field - Field to use for cursor (default: 'created_at')
+ * @returns {string} WHERE clause fragment
+ */
+function getCursorClause(cursor, field = 'created_at') {
+  if (!cursor) return '';
+  return `AND ${field} < '${cursor}'`;
+}
+
+module.exports = {
+  getPaginationParams,
+  getLimitOffsetClause,
+  getPaginatedData,
+  getPaginationMetadata,
+  validatePaginationParams,
+  getCursorClause
+};


### PR DESCRIPTION
### Summary
Implemented offset-based pagination with total count metadata on all list endpoints to resolve issue #498 "Missing Pagination on Most List Endpoints". Critical endpoints like /admin/users, /admin/invoices, /disputes, /quotations, /produce, and /streaming now support limit, offset, and page query parameters with consistent pagination metadata in responses.

### What's New
- ✅ **10+ endpoints** now support offset-based pagination
- ✅ **Pagination utility** (`backend/utils/pagination.js`) for consistent implementation
- ✅ **Total count metadata** in all list responses
- ✅ **Default limit**: 50 records, **Max limit**: 500 records
- ✅ **Consistent response format** across all endpoints
- ✅ **Navigation helpers** (hasNextPage, hasPreviousPage, totalPages)

### Endpoints Updated
1. `GET /api/admin/users` - Get all users with pagination
2. `GET /api/admin/invoices` - Get all invoices with pagination
3. `GET /api/disputes/:invoiceId/evidence` - Get dispute evidence with pagination
4. `GET /api/disputes/:invoiceId/logs` - Get dispute logs with pagination
5. `GET /api/quotations` - Get quotations with pagination
6. `GET /api/quotations/pending-approvals` - Get pending approvals with pagination
7. `GET /api/produce/seller-lots` - Get seller lots with pagination
8. `GET /api/streams/seller` - Get seller streams with pagination
9. `GET /api/streams/buyer` - Get buyer streams with pagination
10. `GET /api/streams/my` - Get all user streams with pagination

### Testing
- ✓ Default pagination (no parameters)
- ✓ Custom limit values (1, 50, 500)
- ✓ Custom offset values
- ✓ Page parameter (converts to offset)
- ✓ Out-of-range pages
- ✓ Invalid parameters
- ✓ Empty results
- ✓ Large datasets

closes: #498
@GauravKarakoti plz review it

